### PR TITLE
feat: 支持非英文函数名

### DIFF
--- a/elisp-docstring-server.el
+++ b/elisp-docstring-server.el
@@ -118,7 +118,11 @@
   (let ((headers (oref req headers))
         (proc (oref req process)))
     ;; (message "[elisp-docstring-server] HEADERS: %S" headers)
-    (let ((symbol (assoc-default "symbol" headers)))
+    (let* ((symbol (assoc-default "symbol" headers))
+           (symbol (if (or (null symbol)
+                           (string= "" symbol))
+                       symbol
+                     (decode-coding-string symbol 'utf-8))))
       (pcase symbol
         ('nil 
          (elisp-docstring-server--end


### PR DESCRIPTION
原始实现不支持中文等其他包含非英文字符的函数名，需要用 `decode-coding-string` 对获取的字符串进行转码